### PR TITLE
languages.json: fix capitalization for ca-valencia

### DIFF
--- a/public/1.0/languages.json
+++ b/public/1.0/languages.json
@@ -81,7 +81,7 @@
     },
     "ca-valencia": {
         "English": "Catalan (Valencian)",
-        "native": "catal\u00e0 (valenci\u00e0)"
+        "native": "Catal\u00e0 (Valenci\u00e0)"
     },
     "cak": {
         "English": "Kaqchikel",


### PR DESCRIPTION
We're [shipping ca-valencia](https://bugzilla.mozilla.org/show_bug.cgi?id=1580088), for some reason the capitalization is off compared to other romance languages. This uses uppercase like other languages (Catalan, Spanish, etc.)