### PR TITLE
Add Tibetan (bo) to languages.json

### DIFF
--- a/public/1.0/languages.json
+++ b/public/1.0/languages.json
@@ -63,6 +63,10 @@
         "English": "Bengali (India)",
         "native": "\u09ac\u09be\u0982\u09b2\u09be (\u09ad\u09be\u09b0\u09a4)"
     },
+    "bo": {
+        "English": "Tibetan",
+        "native": "\u0f56\u0f7c\u0f51\u0f0b\u0f66\u0f90\u0f51\u0f0b"
+    },
     "br": {
         "English": "Breton",
         "native": "Brezhoneg"


### PR DESCRIPTION
We added the language to Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1584920 and have builds, but it's still unlisted on mozilla.org without this PR