### PR TITLE
Add Friulian (fur) and Saraiki (skr) to languages

### DIFF
--- a/public/1.0/languages.json
+++ b/public/1.0/languages.json
@@ -223,6 +223,10 @@
         "English": "French",
         "native": "Fran\u00e7ais"
     },
+    "fur": {
+        "English": "Friulian",
+        "native": "Furlan"
+    },
     "fur-IT": {
         "English": "Friulian",
         "native": "Furlan"
@@ -531,6 +535,10 @@
         "English": "Slovak",
         "native": "sloven\u010dina"
     },
+    "skr": {
+        "English": "Saraiki",
+        "native": "\u0633\u0631\u0627\u0626\u06cc\u06a9\u06cc"
+    },	
     "sl": {
         "English": "Slovenian",
         "native": "Sloven\u0161\u010dina"


### PR DESCRIPTION
There is already a `fur-IT`, but we need a `fur` to allow downloading Nightly builds from mozilla.org (added in [bug 1805837](https://bugzilla.mozilla.org/show_bug.cgi?id=1805837)).

I don't trust just renaming the existing locale code, because I have a feeling there might be users of this data that we're not aware of.