### PR TITLE
Add Luri Bakhtiari (bqi) to languages.json

### DIFF
--- a/public/1.0/languages.json
+++ b/public/1.0/languages.json
@@ -67,6 +67,10 @@
         "English": "Tibetan",
         "native": "\u0f56\u0f7c\u0f51\u0f0b\u0f66\u0f90\u0f51\u0f0b"
     },
+    "bqi": {
+        "English": "Luri Bakhtiari",
+        "native": "\u0644\u0648\u0631\u06cc \u0628\u062e\u062a\u06cc\u0627\u0631\u06cc"
+    },
     "br": {
         "English": "Breton",
         "native": "Brezhoneg"


### PR DESCRIPTION
We are adding a new language to Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=2020533 soon, but it's still unlisted on mozilla.org. This PR adds the `bqi` locale for access once builds start being added.